### PR TITLE
Add folder_iam field to Atlantis config

### DIFF
--- a/generated/java/dapla-kuben-resource-model/src/main/java/no/ssb/dapla/kuben/v1/Atlantis.java
+++ b/generated/java/dapla-kuben-resource-model/src/main/java/no/ssb/dapla/kuben/v1/Atlantis.java
@@ -20,7 +20,8 @@ import jakarta.validation.constraints.NotNull;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "name",
-    "repos"
+    "repos",
+    "folder_iam"
 })
 @Generated("jsonschema2pojo")
 public class Atlantis implements Serializable
@@ -43,10 +44,18 @@ public class Atlantis implements Serializable
     @JsonPropertyDescription("Which repositories under Statistics Norway-organisation this team atlantis instance will monitor.")
     @Valid
     private List<String> repos = new ArrayList<String>();
+    /**
+     * Array of folder bindings to set for the Atlantis SA.
+     * 
+     */
+    @JsonProperty("folder_iam")
+    @JsonPropertyDescription("Array of folder bindings to set for the Atlantis SA.")
+    @Valid
+    private List<FolderIam__1> folderIam = new ArrayList<FolderIam__1>();
     @JsonIgnore
     @Valid
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-    private final static long serialVersionUID = -5763719206269168949L;
+    private final static long serialVersionUID = 854245460037993476L;
 
     /**
      * No args constructor for use in serialization
@@ -59,13 +68,16 @@ public class Atlantis implements Serializable
      * 
      * @param repos
      *     Which repositories under Statistics Norway-organisation this team atlantis instance will monitor.
+     * @param folderIam
+     *     Array of folder bindings to set for the Atlantis SA.
      * @param name
      *     The name of the atlantis instance.
      */
-    public Atlantis(String name, List<String> repos) {
+    public Atlantis(String name, List<String> repos, List<FolderIam__1> folderIam) {
         super();
         this.name = name;
         this.repos = repos;
+        this.folderIam = folderIam;
     }
 
     public static Atlantis.AtlantisBuilderBase builder() {
@@ -110,6 +122,24 @@ public class Atlantis implements Serializable
         this.repos = repos;
     }
 
+    /**
+     * Array of folder bindings to set for the Atlantis SA.
+     * 
+     */
+    @JsonProperty("folder_iam")
+    public List<FolderIam__1> getFolderIam() {
+        return folderIam;
+    }
+
+    /**
+     * Array of folder bindings to set for the Atlantis SA.
+     * 
+     */
+    @JsonProperty("folder_iam")
+    public void setFolderIam(List<FolderIam__1> folderIam) {
+        this.folderIam = folderIam;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -132,6 +162,10 @@ public class Atlantis implements Serializable
         sb.append('=');
         sb.append(((this.repos == null)?"<null>":this.repos));
         sb.append(',');
+        sb.append("folderIam");
+        sb.append('=');
+        sb.append(((this.folderIam == null)?"<null>":this.folderIam));
+        sb.append(',');
         sb.append("additionalProperties");
         sb.append('=');
         sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
@@ -150,6 +184,7 @@ public class Atlantis implements Serializable
         result = ((result* 31)+((this.name == null)? 0 :this.name.hashCode()));
         result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
         result = ((result* 31)+((this.repos == null)? 0 :this.repos.hashCode()));
+        result = ((result* 31)+((this.folderIam == null)? 0 :this.folderIam.hashCode()));
         return result;
     }
 
@@ -162,7 +197,7 @@ public class Atlantis implements Serializable
             return false;
         }
         Atlantis rhs = ((Atlantis) other);
-        return ((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.repos == rhs.repos)||((this.repos!= null)&&this.repos.equals(rhs.repos))));
+        return (((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.repos == rhs.repos)||((this.repos!= null)&&this.repos.equals(rhs.repos))))&&((this.folderIam == rhs.folderIam)||((this.folderIam!= null)&&this.folderIam.equals(rhs.folderIam))));
     }
 
     public static class AtlantisBuilder
@@ -174,8 +209,8 @@ public class Atlantis implements Serializable
             super();
         }
 
-        public AtlantisBuilder(String name, List<String> repos) {
-            super(name, repos);
+        public AtlantisBuilder(String name, List<String> repos, List<FolderIam__1> folderIam) {
+            super(name, repos, folderIam);
         }
 
     }
@@ -193,10 +228,10 @@ public class Atlantis implements Serializable
         }
 
         @SuppressWarnings("unchecked")
-        public AtlantisBuilderBase(String name, List<String> repos) {
+        public AtlantisBuilderBase(String name, List<String> repos, List<FolderIam__1> folderIam) {
             // Skip initialization when called from subclass
             if (this.getClass().equals(Atlantis.AtlantisBuilder.class)) {
-                this.instance = ((T) new Atlantis(name, repos));
+                this.instance = ((T) new Atlantis(name, repos, folderIam));
             }
         }
 
@@ -214,6 +249,11 @@ public class Atlantis implements Serializable
 
         public Atlantis.AtlantisBuilderBase withRepos(List<String> repos) {
             ((Atlantis) this.instance).repos = repos;
+            return this;
+        }
+
+        public Atlantis.AtlantisBuilderBase withFolderIam(List<FolderIam__1> folderIam) {
+            ((Atlantis) this.instance).folderIam = folderIam;
             return this;
         }
 

--- a/generated/java/dapla-kuben-resource-model/src/main/java/no/ssb/dapla/kuben/v1/FolderIam__1.java
+++ b/generated/java/dapla-kuben-resource-model/src/main/java/no/ssb/dapla/kuben/v1/FolderIam__1.java
@@ -29,7 +29,7 @@ public class FolderIam__1 implements Serializable
      */
     @JsonProperty("folder")
     @JsonPropertyDescription("The folder number")
-    private Double folder;
+    private String folder;
     /**
      * The role to grant
      * 
@@ -40,7 +40,7 @@ public class FolderIam__1 implements Serializable
     @JsonIgnore
     @Valid
     private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-    private final static long serialVersionUID = 3406351370337331750L;
+    private final static long serialVersionUID = 4921122945890958437L;
 
     /**
      * No args constructor for use in serialization
@@ -56,7 +56,7 @@ public class FolderIam__1 implements Serializable
      * @param role
      *     The role to grant.
      */
-    public FolderIam__1(Double folder, String role) {
+    public FolderIam__1(String folder, String role) {
         super();
         this.folder = folder;
         this.role = role;
@@ -71,7 +71,7 @@ public class FolderIam__1 implements Serializable
      * 
      */
     @JsonProperty("folder")
-    public Double getFolder() {
+    public String getFolder() {
         return folder;
     }
 
@@ -80,7 +80,7 @@ public class FolderIam__1 implements Serializable
      * 
      */
     @JsonProperty("folder")
-    public void setFolder(Double folder) {
+    public void setFolder(String folder) {
         this.folder = folder;
     }
 
@@ -166,7 +166,7 @@ public class FolderIam__1 implements Serializable
             super();
         }
 
-        public FolderIam__1Builder(Double folder, String role) {
+        public FolderIam__1Builder(String folder, String role) {
             super(folder, role);
         }
 
@@ -185,7 +185,7 @@ public class FolderIam__1 implements Serializable
         }
 
         @SuppressWarnings("unchecked")
-        public FolderIam__1BuilderBase(Double folder, String role) {
+        public FolderIam__1BuilderBase(String folder, String role) {
             // Skip initialization when called from subclass
             if (this.getClass().equals(FolderIam__1 .FolderIam__1Builder.class)) {
                 this.instance = ((T) new FolderIam__1(folder, role));
@@ -199,7 +199,7 @@ public class FolderIam__1 implements Serializable
             return result;
         }
 
-        public FolderIam__1 .FolderIam__1BuilderBase withFolder(Double folder) {
+        public FolderIam__1 .FolderIam__1BuilderBase withFolder(String folder) {
             ((FolderIam__1) this.instance).folder = folder;
             return this;
         }

--- a/generated/java/dapla-kuben-resource-model/src/main/java/no/ssb/dapla/kuben/v1/FolderIam__1.java
+++ b/generated/java/dapla-kuben-resource-model/src/main/java/no/ssb/dapla/kuben/v1/FolderIam__1.java
@@ -1,0 +1,219 @@
+
+package no.ssb.dapla.kuben.v1;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.validation.Valid;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "folder",
+    "role"
+})
+@Generated("jsonschema2pojo")
+public class FolderIam__1 implements Serializable
+{
+
+    /**
+     * The folder number
+     * 
+     */
+    @JsonProperty("folder")
+    @JsonPropertyDescription("The folder number")
+    private Double folder;
+    /**
+     * The role to grant
+     * 
+     */
+    @JsonProperty("role")
+    @JsonPropertyDescription("The role to grant")
+    private String role;
+    @JsonIgnore
+    @Valid
+    private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+    private final static long serialVersionUID = 3406351370337331750L;
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public FolderIam__1() {
+    }
+
+    /**
+     * 
+     * @param folder
+     *     The folder number.
+     * @param role
+     *     The role to grant.
+     */
+    public FolderIam__1(Double folder, String role) {
+        super();
+        this.folder = folder;
+        this.role = role;
+    }
+
+    public static FolderIam__1 .FolderIam__1BuilderBase builder() {
+        return new FolderIam__1 .FolderIam__1Builder();
+    }
+
+    /**
+     * The folder number
+     * 
+     */
+    @JsonProperty("folder")
+    public Double getFolder() {
+        return folder;
+    }
+
+    /**
+     * The folder number
+     * 
+     */
+    @JsonProperty("folder")
+    public void setFolder(Double folder) {
+        this.folder = folder;
+    }
+
+    /**
+     * The role to grant
+     * 
+     */
+    @JsonProperty("role")
+    public String getRole() {
+        return role;
+    }
+
+    /**
+     * The role to grant
+     * 
+     */
+    @JsonProperty("role")
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(FolderIam__1 .class.getName()).append('@').append(Integer.toHexString(System.identityHashCode(this))).append('[');
+        sb.append("folder");
+        sb.append('=');
+        sb.append(((this.folder == null)?"<null>":this.folder));
+        sb.append(',');
+        sb.append("role");
+        sb.append('=');
+        sb.append(((this.role == null)?"<null>":this.role));
+        sb.append(',');
+        sb.append("additionalProperties");
+        sb.append('=');
+        sb.append(((this.additionalProperties == null)?"<null>":this.additionalProperties));
+        sb.append(',');
+        if (sb.charAt((sb.length()- 1)) == ',') {
+            sb.setCharAt((sb.length()- 1), ']');
+        } else {
+            sb.append(']');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ((result* 31)+((this.folder == null)? 0 :this.folder.hashCode()));
+        result = ((result* 31)+((this.role == null)? 0 :this.role.hashCode()));
+        result = ((result* 31)+((this.additionalProperties == null)? 0 :this.additionalProperties.hashCode()));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if ((other instanceof FolderIam__1) == false) {
+            return false;
+        }
+        FolderIam__1 rhs = ((FolderIam__1) other);
+        return ((((this.folder == rhs.folder)||((this.folder!= null)&&this.folder.equals(rhs.folder)))&&((this.role == rhs.role)||((this.role!= null)&&this.role.equals(rhs.role))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
+    }
+
+    public static class FolderIam__1Builder
+        extends FolderIam__1 .FolderIam__1BuilderBase<FolderIam__1>
+    {
+
+
+        public FolderIam__1Builder() {
+            super();
+        }
+
+        public FolderIam__1Builder(Double folder, String role) {
+            super(folder, role);
+        }
+
+    }
+
+    public static abstract class FolderIam__1BuilderBase<T extends FolderIam__1 >{
+
+        protected T instance;
+
+        @SuppressWarnings("unchecked")
+        public FolderIam__1BuilderBase() {
+            // Skip initialization when called from subclass
+            if (this.getClass().equals(FolderIam__1 .FolderIam__1Builder.class)) {
+                this.instance = ((T) new FolderIam__1());
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public FolderIam__1BuilderBase(Double folder, String role) {
+            // Skip initialization when called from subclass
+            if (this.getClass().equals(FolderIam__1 .FolderIam__1Builder.class)) {
+                this.instance = ((T) new FolderIam__1(folder, role));
+            }
+        }
+
+        public T build() {
+            T result;
+            result = this.instance;
+            this.instance = null;
+            return result;
+        }
+
+        public FolderIam__1 .FolderIam__1BuilderBase withFolder(Double folder) {
+            ((FolderIam__1) this.instance).folder = folder;
+            return this;
+        }
+
+        public FolderIam__1 .FolderIam__1BuilderBase withRole(String role) {
+            ((FolderIam__1) this.instance).role = role;
+            return this;
+        }
+
+        public FolderIam__1 .FolderIam__1BuilderBase withAdditionalProperty(String name, Object value) {
+            ((FolderIam__1) this.instance).additionalProperties.put(name, value);
+            return this;
+        }
+
+    }
+
+}

--- a/src/v1/kuben-team-definition.schema.json
+++ b/src/v1/kuben-team-definition.schema.json
@@ -101,6 +101,23 @@
             "type": "string",
             "pattern": "^[a-zA-Z-_.0-9]*$"
           }
+        },
+        "folder_iam": {
+          "type": "array",
+          "description": "Array of folder bindings to set for the Atlantis SA.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "folder": {
+                "type": "number",
+                "description": "The folder number"
+              },
+              "role": {
+                "type": "string",
+                "description": "The role to grant"
+              }
+            }
+          }
         }
       }
     },

--- a/src/v1/kuben-team-definition.schema.json
+++ b/src/v1/kuben-team-definition.schema.json
@@ -109,7 +109,7 @@
             "type": "object",
             "properties": {
               "folder": {
-                "type": "number",
+                "type": "string",
                 "description": "The folder number"
               },
               "role": {


### PR DESCRIPTION
Add a `folder_iam` field to the atlantis config, so we can grant arbitrary roles on folders to each atlantis.

Usage:
```yaml
atlantis:
  folder_iam:
    - folder: "123456"
      role: roles/rolename
```

Implemented as a list of objects instead of a map of folder names to lists of roles, because jsonschema is ...................

NOTE: there are `project_iam` and `bucket_iam` fields in use in the atlantis block today which are not in the schema, probably because the validation action wasn't added at the time.